### PR TITLE
Internal Folder and .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+internal/

--- a/internal/shell-scripts/upload-image.sh
+++ b/internal/shell-scripts/upload-image.sh
@@ -1,0 +1,1 @@
+# Shell script to tag and upload docker images to Docker Hub


### PR DESCRIPTION
Adds an internal folder where we can create shell scripts to manage our workflow without uploading these files to the image as that would be redundant.